### PR TITLE
Implement FastAPI skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 gtk_uploader/uploader
+movieAPI_nodejs/node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+gtk_uploader/uploader

--- a/README.md
+++ b/README.md
@@ -49,3 +49,13 @@ Install dependencies and start the server:
 pip install fastapi uvicorn requests
 uvicorn main:app --reload
 ```
+
+## GTK Movie Uploader
+
+A simple C/GTK program in `gtk_uploader/` lets you append new entries to
+`movies.json`. Build it with `make` (requires `gtk+-3.0`, `libcurl`, and
+`jansson` development headers). Running the resulting `uploader` binary
+provides a small form to submit new movie records. By default the updated
+file is written locally, but you can adapt the program to upload it back to
+GitHub using a personal access token in the `GITHUB_TOKEN` environment
+variable.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,19 @@ pip install fastapi uvicorn requests
 uvicorn main:app --reload
 ```
 
+## Node.js Version
+
+For users that prefer Node.js, a companion implementation lives in
+`movieAPI_nodejs/`. It exposes similar endpoints using Express.
+
+Run it with:
+
+```bash
+cd movieAPI_nodejs
+npm install
+npm start
+```
+
 ## GTK Movie Uploader
 
 A simple C/GTK program in `gtk_uploader/` lets you append new entries to

--- a/README.md
+++ b/README.md
@@ -1,15 +1,21 @@
 # movieAPI
 
-A simple FastAPI application that attempts to fetch movie and anime show data
-from [shows-](https://github.com/Kgkkjjj/shows-/tree/main). The remote
-repository currently contains no actual show lists, so the API endpoints will
-return empty arrays until data files (`movies.json` and `anime.json`) are added
-to that repository.
+A small FastAPI service that fetches movie and anime data from the
+[shows-](https://github.com/Kgkkjjj/shows-/tree/main) repository. The remote
+repository does not currently provide real data, so responses are empty until
+`movies.json` and `anime.json` are published there.
+
+In addition to basic list endpoints, this API offers simple lookup and search
+functionality similar to larger movie databases.
 
 ## Endpoints
 
 - `/movies` - Returns a list of movies from the remote repo.
+- `/movies/{id}` - Look up a movie by numeric `id`.
+- `/movies/search?q=title` - Search movies by title substring.
 - `/anime` - Returns a list of anime from the remote repo.
+- `/anime/{id}` - Look up an anime show by numeric `id`.
+- `/anime/search?q=title` - Search anime by title substring.
 
 ## Running
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ functionality similar to larger movie databases.
 - `/movies/stats` - Summary stats for movie file sizes.
 - `/movies/sorted_by_size` - Movies sorted by file size.
 - `/movies/sorted_by_episode` - Movies sorted by season/episode.
+- `/movies/sorted_by_title` - Movies sorted alphabetically by title.
+- `/movies/latest` - Retrieve the most recent movie.
 - `/movies/by_season/{season}` - Movies within a season.
 - `/movies/shows/{show}/season/{season}` - Movies for a show and season.
 - `/movies/shows/{show}/episode/{episode}` - Movies for a show and episode.
@@ -34,6 +36,8 @@ functionality similar to larger movie databases.
 - `/anime` - Returns a list of anime from the remote repo.
 - `/anime/count` - Total count of anime entries.
 - `/anime/random` - Retrieve a random anime show.
+- `/anime/sorted_by_title` - Anime shows sorted alphabetically by title.
+- `/anime/latest` - Retrieve the last anime show in the list.
 - `/anime/{id}` - Look up an anime show by numeric `id`.
 - `/anime/search?q=title` - Search anime by title substring.
 

--- a/README.md
+++ b/README.md
@@ -64,3 +64,17 @@ provides a small form to submit new movie records. By default the updated
 file is written locally, but you can adapt the program to upload it back to
 GitHub using a personal access token in the `GITHUB_TOKEN` environment
 variable.
+
+## Updating `movies.json`
+
+The repository includes a helper script `update_movies.py` that downloads
+`movies.json` from the upstream repository and commits the updated file. If
+you have the GPG key `9F28B4FCD2B9A0BE` available, the script attempts to
+sign the commit. Usage:
+
+```bash
+python update_movies.py "Update movies.json"
+```
+
+If signing fails (e.g. the key is not present), the commit will be created
+without a signature.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # movieAPI
+
+A simple FastAPI application that attempts to fetch movie and anime show data
+from [shows-](https://github.com/Kgkkjjj/shows-/tree/main). The remote
+repository currently contains no actual show lists, so the API endpoints will
+return empty arrays until data files (`movies.json` and `anime.json`) are added
+to that repository.
+
+## Endpoints
+
+- `/movies` - Returns a list of movies from the remote repo.
+- `/anime` - Returns a list of anime from the remote repo.
+
+## Running
+
+Install dependencies and start the server:
+
+```bash
+pip install fastapi uvicorn requests
+uvicorn main:app --reload
+```

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ functionality similar to larger movie databases.
 - `/anime/latest` - Retrieve the last anime show in the list.
 - `/anime/{id}` - Look up an anime show by numeric `id`.
 - `/anime/search?q=title` - Search anime by title substring.
+- `/refresh` (POST) - Force refresh of cached data from GitHub.
+
+The service caches movie and anime data in memory for five minutes to
+avoid repeatedly hitting the upstream repository. Use `/refresh` if you need
+to force an update immediately.
 
 ## Running
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,22 @@ functionality similar to larger movie databases.
 - `/movies/search?q=title` - Search movies by title substring.
 - `/movies/by_size?min=&max=` - Filter movies by file size in MB.
 - `/movies/shows/{show}` - List all movies for a particular show name.
+- `/movies/count` - Total count of available movies.
+- `/movies/stats` - Summary stats for movie file sizes.
+- `/movies/sorted_by_size` - Movies sorted by file size.
+- `/movies/sorted_by_episode` - Movies sorted by season/episode.
+- `/movies/by_season/{season}` - Movies within a season.
+- `/movies/shows/{show}/season/{season}` - Movies for a show and season.
+- `/movies/shows/{show}/episode/{episode}` - Movies for a show and episode.
+- `/movies/random` - Retrieve a random movie.
 - `/shows` - List all unique show names present in the movie dataset.
+- `/shows/search?q=name` - Search show names.
 - `/shows/{show}/seasons` - List seasons available for a show.
+- `/shows/{show}/summary` - Map seasons to episode lists.
 - `/shows/{show}/seasons/{season}/episodes` - List episodes for a specific season.
 - `/anime` - Returns a list of anime from the remote repo.
+- `/anime/count` - Total count of anime entries.
+- `/anime/random` - Retrieve a random anime show.
 - `/anime/{id}` - Look up an anime show by numeric `id`.
 - `/anime/search?q=title` - Search anime by title substring.
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ functionality similar to larger movie databases.
 - `/movies/search?q=title` - Search movies by title substring.
 - `/movies/by_size?min=&max=` - Filter movies by file size in MB.
 - `/movies/shows/{show}` - List all movies for a particular show name.
+- `/shows` - List all unique show names present in the movie dataset.
+- `/shows/{show}/seasons` - List seasons available for a show.
+- `/shows/{show}/seasons/{season}/episodes` - List episodes for a specific season.
 - `/anime` - Returns a list of anime from the remote repo.
 - `/anime/{id}` - Look up an anime show by numeric `id`.
 - `/anime/search?q=title` - Search anime by title substring.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@
 A small FastAPI service that fetches movie and anime data from the
 [shows-](https://github.com/Kgkkjjj/shows-/tree/main) repository. The remote
 repository does not currently provide real data, so responses are empty until
-`movies.json` and `anime.json` are published there.
+`movies.json` and `anime.json` are published there. As of this writing
+[`movies.json`](https://github.com/Kgkkjjj/shows-/blob/main/movies.json)
+contains eight episodes of the show **Wednesday**, each with a file size.
+The API assigns sequential IDs when loading this data.
 
 In addition to basic list endpoints, this API offers simple lookup and search
 functionality similar to larger movie databases.
@@ -13,6 +16,8 @@ functionality similar to larger movie databases.
 - `/movies` - Returns a list of movies from the remote repo.
 - `/movies/{id}` - Look up a movie by numeric `id`.
 - `/movies/search?q=title` - Search movies by title substring.
+- `/movies/by_size?min=&max=` - Filter movies by file size in MB.
+- `/movies/shows/{show}` - List all movies for a particular show name.
 - `/anime` - Returns a list of anime from the remote repo.
 - `/anime/{id}` - Look up an anime show by numeric `id`.
 - `/anime/search?q=title` - Search anime by title substring.

--- a/data_loader.py
+++ b/data_loader.py
@@ -1,0 +1,26 @@
+import json
+import requests
+from typing import List
+
+REPO_BASE_URL = 'https://raw.githubusercontent.com/Kgkkjjj/shows-/main/'
+MOVIES_FILE = 'movies.json'
+ANIME_FILE = 'anime.json'
+
+
+def fetch_remote_json(filename: str) -> List[dict]:
+    url = REPO_BASE_URL + filename
+    try:
+        resp = requests.get(url, timeout=5)
+        resp.raise_for_status()
+        return resp.json()
+    except Exception:
+        # If the file isn't found or can't be parsed, return empty list
+        return []
+
+
+def get_movies() -> List[dict]:
+    return fetch_remote_json(MOVIES_FILE)
+
+
+def get_anime() -> List[dict]:
+    return fetch_remote_json(ANIME_FILE)

--- a/data_loader.py
+++ b/data_loader.py
@@ -1,6 +1,7 @@
 import json
 import requests
 from typing import List, Optional
+import re
 
 REPO_BASE_URL = 'https://raw.githubusercontent.com/Kgkkjjj/shows-/main/'
 MOVIES_FILE = 'movies.json'
@@ -18,8 +19,32 @@ def fetch_remote_json(filename: str) -> List[dict]:
         return []
 
 
+def _parse_title(title: str):
+    """Extract show name, season and episode from a title string."""
+    m = re.search(r"^(?P<show>[^.]+)\.S(?P<season>\d+)E(?P<episode>\d+)", title)
+    if m:
+        return m.group("show"), int(m.group("season")), int(m.group("episode"))
+    return None, None, None
+
+
 def get_movies() -> List[dict]:
-    return fetch_remote_json(MOVIES_FILE)
+    """Return list of movies enriched with ids and parsed fields."""
+    raw = fetch_remote_json(MOVIES_FILE)
+    movies = []
+    for idx, item in enumerate(raw, 1):
+        show, season, episode = _parse_title(item.get("title", ""))
+        movies.append(
+            {
+                "id": idx,
+                "title": item.get("title"),
+                "path": item.get("path"),
+                "size_mb": item.get("size_mb"),
+                "show": show,
+                "season": season,
+                "episode": episode,
+            }
+        )
+    return movies
 
 
 def get_anime() -> List[dict]:
@@ -46,6 +71,21 @@ def search_movies(title: str) -> List[dict]:
     """Simple case-insensitive search by title substring."""
     query = title.lower()
     return [m for m in get_movies() if query in str(m.get("title", "")).lower()]
+
+
+def filter_movies_by_size(min_size: float, max_size: float) -> List[dict]:
+    """Return movies within a size range in megabytes."""
+    return [
+        m
+        for m in get_movies()
+        if m.get("size_mb") is not None and min_size <= float(m["size_mb"]) <= max_size
+    ]
+
+
+def get_movies_by_show(show_name: str) -> List[dict]:
+    """Return all movies that match a show name (case-insensitive)."""
+    query = show_name.lower()
+    return [m for m in get_movies() if m.get("show", "").lower() == query]
 
 
 def search_anime(title: str) -> List[dict]:

--- a/data_loader.py
+++ b/data_loader.py
@@ -3,10 +3,18 @@ import requests
 from typing import List, Optional
 import re
 import random
+import time
 
 REPO_BASE_URL = 'https://raw.githubusercontent.com/Kgkkjjj/shows-/main/'
 MOVIES_FILE = 'movies.json'
 ANIME_FILE = 'anime.json'
+
+# simple in-memory caches for remote data
+MOVIES_CACHE: List[dict] = []
+ANIME_CACHE: List[dict] = []
+MOVIES_CACHE_TIME = 0.0
+ANIME_CACHE_TIME = 0.0
+CACHE_TTL = 300  # seconds
 
 
 def fetch_remote_json(filename: str) -> List[dict]:
@@ -28,8 +36,12 @@ def _parse_title(title: str):
     return None, None, None
 
 
-def get_movies() -> List[dict]:
+def get_movies(force_refresh: bool = False) -> List[dict]:
     """Return list of movies enriched with ids and parsed fields."""
+    global MOVIES_CACHE, MOVIES_CACHE_TIME
+    if not force_refresh and MOVIES_CACHE and time.time() - MOVIES_CACHE_TIME < CACHE_TTL:
+        return MOVIES_CACHE
+
     raw = fetch_remote_json(MOVIES_FILE)
     movies = []
     for idx, item in enumerate(raw, 1):
@@ -45,6 +57,9 @@ def get_movies() -> List[dict]:
                 "episode": episode,
             }
         )
+
+    MOVIES_CACHE = movies
+    MOVIES_CACHE_TIME = time.time()
     return movies
 
 
@@ -71,8 +86,22 @@ def get_episodes_for_show_season(show_name: str, season: int) -> List[dict]:
     ]
 
 
-def get_anime() -> List[dict]:
-    return fetch_remote_json(ANIME_FILE)
+def get_anime(force_refresh: bool = False) -> List[dict]:
+    global ANIME_CACHE, ANIME_CACHE_TIME
+    if not force_refresh and ANIME_CACHE and time.time() - ANIME_CACHE_TIME < CACHE_TTL:
+        return ANIME_CACHE
+
+    data = fetch_remote_json(ANIME_FILE)
+    ANIME_CACHE = data
+    ANIME_CACHE_TIME = time.time()
+    return data
+
+
+def refresh_cache() -> dict:
+    """Force refresh of both movies and anime caches."""
+    movies = get_movies(force_refresh=True)
+    anime = get_anime(force_refresh=True)
+    return {"movies": len(movies), "anime": len(anime)}
 
 
 def get_movie(movie_id: int) -> Optional[dict]:

--- a/data_loader.py
+++ b/data_loader.py
@@ -1,6 +1,6 @@
 import json
 import requests
-from typing import List
+from typing import List, Optional
 
 REPO_BASE_URL = 'https://raw.githubusercontent.com/Kgkkjjj/shows-/main/'
 MOVIES_FILE = 'movies.json'
@@ -24,3 +24,30 @@ def get_movies() -> List[dict]:
 
 def get_anime() -> List[dict]:
     return fetch_remote_json(ANIME_FILE)
+
+
+def get_movie(movie_id: int) -> Optional[dict]:
+    """Return a single movie by ID or None if not found."""
+    for movie in get_movies():
+        if movie.get("id") == movie_id:
+            return movie
+    return None
+
+
+def get_anime_item(anime_id: int) -> Optional[dict]:
+    """Return a single anime by ID or None if not found."""
+    for show in get_anime():
+        if show.get("id") == anime_id:
+            return show
+    return None
+
+
+def search_movies(title: str) -> List[dict]:
+    """Simple case-insensitive search by title substring."""
+    query = title.lower()
+    return [m for m in get_movies() if query in str(m.get("title", "")).lower()]
+
+
+def search_anime(title: str) -> List[dict]:
+    query = title.lower()
+    return [a for a in get_anime() if query in str(a.get("title", "")).lower()]

--- a/data_loader.py
+++ b/data_loader.py
@@ -227,3 +227,18 @@ def get_latest_movie() -> Optional[dict]:
     """Return the movie with the highest season/episode."""
     movies = sort_movies_by_episode(order="desc")
     return movies[0] if movies else None
+
+
+def get_latest_anime() -> Optional[dict]:
+    """Return the last anime show in the list if available."""
+    shows = get_anime()
+    return shows[-1] if shows else None
+
+
+def sort_anime_by_title(order: str = "asc") -> List[dict]:
+    """Return anime shows sorted alphabetically by title."""
+    shows = sorted(get_anime(), key=lambda a: a.get("title", ""))
+    if order == "desc":
+        shows.reverse()
+    return shows
+

--- a/data_loader.py
+++ b/data_loader.py
@@ -2,6 +2,7 @@ import json
 import requests
 from typing import List, Optional
 import re
+import random
 
 REPO_BASE_URL = 'https://raw.githubusercontent.com/Kgkkjjj/shows-/main/'
 MOVIES_FILE = 'movies.json'
@@ -114,3 +115,115 @@ def get_movies_by_show(show_name: str) -> List[dict]:
 def search_anime(title: str) -> List[dict]:
     query = title.lower()
     return [a for a in get_anime() if query in str(a.get("title", "")).lower()]
+
+
+# Additional helper systems
+def get_movie_count() -> int:
+    """Return the total number of movies available."""
+    return len(get_movies())
+
+
+def get_movie_stats() -> dict:
+    """Return simple statistics about movie sizes."""
+    movies = get_movies()
+    sizes = [float(m["size_mb"]) for m in movies if m.get("size_mb") is not None]
+    total = sum(sizes)
+    avg = total / len(sizes) if sizes else 0.0
+    return {"count": len(movies), "total_size_mb": total, "avg_size_mb": avg}
+
+
+def sort_movies_by_size(order: str = "asc") -> List[dict]:
+    """Return movies sorted by file size."""
+    movies = sorted(
+        get_movies(), key=lambda m: (m.get("size_mb") is None, m.get("size_mb", 0.0))
+    )
+    if order == "desc":
+        movies.reverse()
+    return movies
+
+
+def sort_movies_by_episode(order: str = "asc") -> List[dict]:
+    """Return movies sorted by season/episode."""
+    movies = sorted(
+        get_movies(), key=lambda m: (m.get("season", 0), m.get("episode", 0))
+    )
+    if order == "desc":
+        movies.reverse()
+    return movies
+
+
+def sort_movies_by_title(order: str = "asc") -> List[dict]:
+    """Return movies sorted by title."""
+    movies = sorted(get_movies(), key=lambda m: m.get("title", ""))
+    if order == "desc":
+        movies.reverse()
+    return movies
+
+
+def filter_movies_by_season(season: int) -> List[dict]:
+    """Return all movies for a given season number."""
+    return [m for m in get_movies() if m.get("season") == season]
+
+
+def filter_movies_by_show_season(show: str, season: int) -> List[dict]:
+    """Return movies for a show filtered by season."""
+    query = show.lower()
+    return [
+        m
+        for m in get_movies()
+        if m.get("show", "").lower() == query and m.get("season") == season
+    ]
+
+
+def filter_movies_by_show_episode(show: str, episode: int) -> List[dict]:
+    """Return movies for a show filtered by episode number."""
+    query = show.lower()
+    return [
+        m
+        for m in get_movies()
+        if m.get("show", "").lower() == query and m.get("episode") == episode
+    ]
+
+
+def get_random_movie() -> Optional[dict]:
+    """Return a random movie if available."""
+    movies = get_movies()
+    return random.choice(movies) if movies else None
+
+
+def get_random_anime() -> Optional[dict]:
+    """Return a random anime show if available."""
+    shows = get_anime()
+    return random.choice(shows) if shows else None
+
+
+def search_shows(query: str) -> List[str]:
+    """Case-insensitive search across available show names."""
+    q = query.lower()
+    return [s for s in get_unique_shows() if q in s.lower()]
+
+
+def get_show_summary(show: str) -> dict:
+    """Return mapping of seasons to episode numbers for a show."""
+    episodes = get_movies_by_show(show)
+    summary = {}
+    for m in episodes:
+        season = m.get("season")
+        ep = m.get("episode")
+        if season is None or ep is None:
+            continue
+        summary.setdefault(season, []).append(ep)
+    for season in summary:
+        summary[season] = sorted(summary[season])
+    return {k: summary[k] for k in sorted(summary)}
+
+
+def get_anime_count() -> int:
+    """Return the number of anime shows available."""
+    return len(get_anime())
+
+
+def get_latest_movie() -> Optional[dict]:
+    """Return the movie with the highest season/episode."""
+    movies = sort_movies_by_episode(order="desc")
+    return movies[0] if movies else None

--- a/data_loader.py
+++ b/data_loader.py
@@ -47,6 +47,29 @@ def get_movies() -> List[dict]:
     return movies
 
 
+def get_unique_shows() -> List[str]:
+    """Return a sorted list of unique show names present in the movies."""
+    shows = {m["show"] for m in get_movies() if m.get("show")}
+    return sorted(shows)
+
+
+def get_seasons_for_show(show_name: str) -> List[int]:
+    """Return a sorted list of seasons for a given show."""
+    query = show_name.lower()
+    seasons = {m["season"] for m in get_movies() if m.get("show", "").lower() == query and m.get("season") is not None}
+    return sorted(seasons)
+
+
+def get_episodes_for_show_season(show_name: str, season: int) -> List[dict]:
+    """Return movies that match a show name and season number."""
+    query = show_name.lower()
+    return [
+        m
+        for m in get_movies()
+        if m.get("show", "").lower() == query and m.get("season") == season
+    ]
+
+
 def get_anime() -> List[dict]:
     return fetch_remote_json(ANIME_FILE)
 

--- a/gtk_uploader/Makefile
+++ b/gtk_uploader/Makefile
@@ -1,0 +1,9 @@
+CC = gcc
+CFLAGS = `pkg-config --cflags gtk+-3.0 libcurl jansson`
+LIBS = `pkg-config --libs gtk+-3.0 libcurl jansson`
+
+uploader: main.c
+	$(CC) -o uploader main.c $(CFLAGS) $(LIBS)
+
+clean:
+	rm -f uploader

--- a/gtk_uploader/README.md
+++ b/gtk_uploader/README.md
@@ -1,0 +1,26 @@
+# GTK Movie Uploader
+
+This small GUI program allows you to append entries to
+[`movies.json`](https://github.com/Kgkkjjj/shows-/blob/main/movies.json`).
+It fetches the existing file from GitHub, adds a new movie entry, and
+saves the result locally. If you set a `GITHUB_TOKEN` environment variable,
+you can extend the code to upload the modified file back to GitHub using the
+REST API.
+
+## Building
+
+Make sure `gtk+-3.0`, `libcurl`, and `jansson` development packages are
+installed. Then run:
+
+```bash
+make
+```
+
+This produces an executable named `uploader`.
+
+## Running
+
+Execute the binary and fill in the title, path, and size fields. Clicking
+**Upload** downloads the current JSON file, appends your entry, and writes the
+updated file to `movies.json`. Uploading to GitHub requires additional logic
+and a personal access token set in `GITHUB_TOKEN`.

--- a/gtk_uploader/main.c
+++ b/gtk_uploader/main.c
@@ -1,0 +1,116 @@
+#include <gtk/gtk.h>
+#include <jansson.h>
+#include <curl/curl.h>
+
+/* Helper structure to hold downloaded data */
+typedef struct {
+    GString *str;
+} Buffer;
+
+static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *userdata) {
+    Buffer *buf = (Buffer *)userdata;
+    g_string_append_len(buf->str, ptr, size * nmemb);
+    return size * nmemb;
+}
+
+static GtkWidget *title_entry;
+static GtkWidget *path_entry;
+static GtkWidget *size_entry;
+
+static void on_upload_clicked(GtkButton *button, gpointer user_data) {
+    const char *title = gtk_entry_get_text(GTK_ENTRY(title_entry));
+    const char *path = gtk_entry_get_text(GTK_ENTRY(path_entry));
+    const char *size_text = gtk_entry_get_text(GTK_ENTRY(size_entry));
+    double size = g_ascii_strtod(size_text, NULL);
+
+    CURL *curl = curl_easy_init();
+    Buffer buf = { g_string_new(NULL) };
+
+    curl_easy_setopt(curl, CURLOPT_URL, "https://raw.githubusercontent.com/Kgkkjjj/shows-/main/movies.json");
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &buf);
+    CURLcode res = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
+
+    if (res != CURLE_OK) {
+        g_warning("Failed to fetch movies.json: %s", curl_easy_strerror(res));
+        g_string_free(buf.str, TRUE);
+        return;
+    }
+
+    json_error_t jerr;
+    json_t *root = json_loads(buf.str->str, 0, &jerr);
+    g_string_free(buf.str, TRUE);
+
+    if (!root || !json_is_array(root)) {
+        g_warning("Invalid JSON format: %s", jerr.text);
+        if(root) json_decref(root);
+        return;
+    }
+
+    json_t *item = json_pack("{s:s,s:s,s:f}",
+                             "title", title,
+                             "path", path,
+                             "size_mb", size);
+    json_array_append_new(root, item);
+
+    char *out = json_dumps(root, JSON_INDENT(2));
+    json_decref(root);
+
+    /* Save updated file locally */
+    g_file_set_contents("movies.json", out, -1, NULL);
+
+    const char *token = g_getenv("GITHUB_TOKEN");
+    if (token && *token) {
+        /*
+         * TODO: Implement GitHub API upload with token.
+         * This typically involves a PUT request to
+         * https://api.github.com/repos/Kgkkjjj/shows-/contents/movies.json
+         * with appropriate JSON payload containing the new file content
+         * and commit message.
+         */
+        g_message("Token found. Upload logic not implemented in this example.");
+    } else {
+        g_message("GITHUB_TOKEN not set. Saved movies.json locally only.");
+    }
+
+    g_free(out);
+}
+
+int main(int argc, char **argv) {
+    gtk_init(&argc, &argv);
+
+    GtkWidget *window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+    gtk_window_set_title(GTK_WINDOW(window), "Movie Uploader");
+    gtk_container_set_border_width(GTK_CONTAINER(window), 10);
+
+    GtkWidget *grid = gtk_grid_new();
+    gtk_grid_set_row_spacing(GTK_GRID(grid), 5);
+    gtk_grid_set_column_spacing(GTK_GRID(grid), 5);
+    gtk_container_add(GTK_CONTAINER(window), grid);
+
+    GtkWidget *title_label = gtk_label_new("Title:");
+    title_entry = gtk_entry_new();
+    gtk_grid_attach(GTK_GRID(grid), title_label, 0, 0, 1, 1);
+    gtk_grid_attach(GTK_GRID(grid), title_entry, 1, 0, 1, 1);
+
+    GtkWidget *path_label = gtk_label_new("Path:");
+    path_entry = gtk_entry_new();
+    gtk_grid_attach(GTK_GRID(grid), path_label, 0, 1, 1, 1);
+    gtk_grid_attach(GTK_GRID(grid), path_entry, 1, 1, 1, 1);
+
+    GtkWidget *size_label = gtk_label_new("Size MB:");
+    size_entry = gtk_entry_new();
+    gtk_grid_attach(GTK_GRID(grid), size_label, 0, 2, 1, 1);
+    gtk_grid_attach(GTK_GRID(grid), size_entry, 1, 2, 1, 1);
+
+    GtkWidget *upload_btn = gtk_button_new_with_label("Upload");
+    g_signal_connect(upload_btn, "clicked", G_CALLBACK(on_upload_clicked), NULL);
+    gtk_grid_attach(GTK_GRID(grid), upload_btn, 0, 3, 2, 1);
+
+    g_signal_connect(window, "destroy", G_CALLBACK(gtk_main_quit), NULL);
+
+    gtk_widget_show_all(window);
+    gtk_main();
+    return 0;
+}

--- a/main.py
+++ b/main.py
@@ -24,6 +24,10 @@ from data_loader import (
     search_shows,
     get_show_summary,
     get_anime_count,
+    get_latest_movie,
+    get_latest_anime,
+    sort_movies_by_title,
+    sort_anime_by_title,
 )
 
 app = FastAPI(title="movieAPI")
@@ -55,6 +59,21 @@ def movies_sorted_by_size(order: str = "asc"):
 def movies_sorted_by_episode(order: str = "asc"):
     """Return movies sorted by season/episode order."""
     return {"movies": sort_movies_by_episode(order)}
+
+
+@app.get("/movies/sorted_by_title")
+def movies_sorted_by_title(order: str = "asc"):
+    """Return movies sorted alphabetically by title."""
+    return {"movies": sort_movies_by_title(order)}
+
+
+@app.get("/movies/latest")
+def movie_latest():
+    """Return the most recent movie based on season/episode."""
+    movie = get_latest_movie()
+    if movie is None:
+        raise HTTPException(status_code=404, detail="No movies available")
+    return movie
 
 
 @app.get("/movies/by_season/{season}")
@@ -153,6 +172,21 @@ def anime_count():
 def anime_random():
     """Return a random anime show."""
     show = get_random_anime()
+    if show is None:
+        raise HTTPException(status_code=404, detail="No anime available")
+    return show
+
+
+@app.get("/anime/sorted_by_title")
+def anime_sorted_by_title(order: str = "asc"):
+    """Return anime shows sorted alphabetically by title."""
+    return {"anime": sort_anime_by_title(order)}
+
+
+@app.get("/anime/latest")
+def anime_latest():
+    """Return the last anime show in the list."""
+    show = get_latest_anime()
     if show is None:
         raise HTTPException(status_code=404, detail="No anime available")
     return show

--- a/main.py
+++ b/main.py
@@ -1,0 +1,12 @@
+from fastapi import FastAPI
+from data_loader import get_movies, get_anime
+
+app = FastAPI(title="movieAPI")
+
+@app.get("/movies")
+def movies():
+    return {"movies": get_movies()}
+
+@app.get("/anime")
+def anime():
+    return {"anime": get_anime()}

--- a/main.py
+++ b/main.py
@@ -28,9 +28,16 @@ from data_loader import (
     get_latest_anime,
     sort_movies_by_title,
     sort_anime_by_title,
+    refresh_cache,
 )
 
 app = FastAPI(title="movieAPI")
+
+
+@app.post("/refresh")
+def refresh():
+    """Force refresh of cached remote data."""
+    return refresh_cache()
 
 @app.get("/movies")
 def movies():

--- a/main.py
+++ b/main.py
@@ -6,6 +6,8 @@ from data_loader import (
     get_anime_item,
     search_movies,
     search_anime,
+    filter_movies_by_size,
+    get_movies_by_show,
 )
 
 app = FastAPI(title="movieAPI")
@@ -18,6 +20,18 @@ def movies():
 @app.get("/movies/search")
 def movie_search(q: str):
     return {"movies": search_movies(q)}
+
+
+@app.get("/movies/by_size")
+def movie_by_size(min: float = 0.0, max: float = 1e9):
+    """Filter movies by file size in MB."""
+    return {"movies": filter_movies_by_size(min, max)}
+
+
+@app.get("/movies/shows/{show}")
+def movies_for_show(show: str):
+    """Return all movies belonging to a given show name."""
+    return {"movies": get_movies_by_show(show)}
 
 
 @app.get("/movies/{movie_id}")

--- a/main.py
+++ b/main.py
@@ -8,6 +8,9 @@ from data_loader import (
     search_anime,
     filter_movies_by_size,
     get_movies_by_show,
+    get_unique_shows,
+    get_seasons_for_show,
+    get_episodes_for_show_season,
 )
 
 app = FastAPI(title="movieAPI")
@@ -32,6 +35,24 @@ def movie_by_size(min: float = 0.0, max: float = 1e9):
 def movies_for_show(show: str):
     """Return all movies belonging to a given show name."""
     return {"movies": get_movies_by_show(show)}
+
+
+@app.get("/shows")
+def list_shows():
+    """List unique show names."""
+    return {"shows": get_unique_shows()}
+
+
+@app.get("/shows/{show}/seasons")
+def show_seasons(show: str):
+    """List seasons available for a given show."""
+    return {"seasons": get_seasons_for_show(show)}
+
+
+@app.get("/shows/{show}/seasons/{season}/episodes")
+def show_episodes(show: str, season: int):
+    """List episodes for a specific show and season."""
+    return {"episodes": get_episodes_for_show_season(show, season)}
 
 
 @app.get("/movies/{movie_id}")

--- a/main.py
+++ b/main.py
@@ -11,6 +11,19 @@ from data_loader import (
     get_unique_shows,
     get_seasons_for_show,
     get_episodes_for_show_season,
+    # new helpers
+    get_movie_count,
+    get_movie_stats,
+    sort_movies_by_size,
+    sort_movies_by_episode,
+    filter_movies_by_season,
+    filter_movies_by_show_season,
+    filter_movies_by_show_episode,
+    get_random_movie,
+    get_random_anime,
+    search_shows,
+    get_show_summary,
+    get_anime_count,
 )
 
 app = FastAPI(title="movieAPI")
@@ -18,6 +31,57 @@ app = FastAPI(title="movieAPI")
 @app.get("/movies")
 def movies():
     return {"movies": get_movies()}
+
+
+@app.get("/movies/count")
+def movie_count():
+    """Return total number of movies."""
+    return {"count": get_movie_count()}
+
+
+@app.get("/movies/stats")
+def movie_stats():
+    """Return aggregate statistics about movie file sizes."""
+    return get_movie_stats()
+
+
+@app.get("/movies/sorted_by_size")
+def movies_sorted_by_size(order: str = "asc"):
+    """Return movies sorted by file size."""
+    return {"movies": sort_movies_by_size(order)}
+
+
+@app.get("/movies/sorted_by_episode")
+def movies_sorted_by_episode(order: str = "asc"):
+    """Return movies sorted by season/episode order."""
+    return {"movies": sort_movies_by_episode(order)}
+
+
+@app.get("/movies/by_season/{season}")
+def movies_by_season(season: int):
+    """Return all movies in a given season."""
+    return {"movies": filter_movies_by_season(season)}
+
+
+@app.get("/movies/shows/{show}/season/{season}")
+def movies_show_season(show: str, season: int):
+    """Movies for a show filtered by season."""
+    return {"movies": filter_movies_by_show_season(show, season)}
+
+
+@app.get("/movies/shows/{show}/episode/{episode}")
+def movies_show_episode(show: str, episode: int):
+    """Movies for a show filtered by episode."""
+    return {"movies": filter_movies_by_show_episode(show, episode)}
+
+
+@app.get("/movies/random")
+def movie_random():
+    """Return a random movie."""
+    movie = get_random_movie()
+    if movie is None:
+        raise HTTPException(status_code=404, detail="No movies available")
+    return movie
 
 
 @app.get("/movies/search")
@@ -37,6 +101,12 @@ def movies_for_show(show: str):
     return {"movies": get_movies_by_show(show)}
 
 
+@app.get("/shows/search")
+def shows_search(q: str):
+    """Search available show names."""
+    return {"shows": search_shows(q)}
+
+
 @app.get("/shows")
 def list_shows():
     """List unique show names."""
@@ -47,6 +117,12 @@ def list_shows():
 def show_seasons(show: str):
     """List seasons available for a given show."""
     return {"seasons": get_seasons_for_show(show)}
+
+
+@app.get("/shows/{show}/summary")
+def show_summary(show: str):
+    """Return mapping of seasons to episodes for a show."""
+    return {"summary": get_show_summary(show)}
 
 
 @app.get("/shows/{show}/seasons/{season}/episodes")
@@ -65,6 +141,21 @@ def movie_detail(movie_id: int):
 @app.get("/anime")
 def anime():
     return {"anime": get_anime()}
+
+
+@app.get("/anime/count")
+def anime_count():
+    """Return number of anime shows."""
+    return {"count": get_anime_count()}
+
+
+@app.get("/anime/random")
+def anime_random():
+    """Return a random anime show."""
+    show = get_random_anime()
+    if show is None:
+        raise HTTPException(status_code=404, detail="No anime available")
+    return show
 
 
 @app.get("/anime/search")

--- a/main.py
+++ b/main.py
@@ -1,5 +1,12 @@
-from fastapi import FastAPI
-from data_loader import get_movies, get_anime
+from fastapi import FastAPI, HTTPException
+from data_loader import (
+    get_movies,
+    get_anime,
+    get_movie,
+    get_anime_item,
+    search_movies,
+    search_anime,
+)
 
 app = FastAPI(title="movieAPI")
 
@@ -7,6 +14,32 @@ app = FastAPI(title="movieAPI")
 def movies():
     return {"movies": get_movies()}
 
+
+@app.get("/movies/search")
+def movie_search(q: str):
+    return {"movies": search_movies(q)}
+
+
+@app.get("/movies/{movie_id}")
+def movie_detail(movie_id: int):
+    movie = get_movie(movie_id)
+    if movie is None:
+        raise HTTPException(status_code=404, detail="Movie not found")
+    return movie
+
 @app.get("/anime")
 def anime():
     return {"anime": get_anime()}
+
+
+@app.get("/anime/search")
+def anime_search(q: str):
+    return {"anime": search_anime(q)}
+
+
+@app.get("/anime/{anime_id}")
+def anime_detail(anime_id: int):
+    show = get_anime_item(anime_id)
+    if show is None:
+        raise HTTPException(status_code=404, detail="Anime not found")
+    return show

--- a/movieAPI_nodejs/README.md
+++ b/movieAPI_nodejs/README.md
@@ -1,0 +1,29 @@
+# movieAPI Node.js
+
+A minimal Express server that mirrors the features of the Python `movieAPI`.
+It fetches `movies.json` and `anime.json` from the upstream
+[shows-](https://github.com/Kgkkjjj/shows-/tree/main) repository, caches the
+results in memory, and exposes several endpoints.
+
+## Endpoints
+
+- `GET /movies` - List all movies.
+- `GET /movies/:id` - Retrieve a movie by numeric ID.
+- `GET /movies/search?q=` - Search movie titles.
+- `GET /anime` - List all anime shows.
+- `GET /anime/:id` - Retrieve an anime show by ID.
+- `GET /anime/search?q=` - Search anime titles.
+- `POST /refresh` - Force refresh of cached data.
+
+## Running
+
+Install dependencies and start the server:
+
+```bash
+cd movieAPI_nodejs
+npm install
+npm start
+```
+
+The server listens on port `3000` by default. Set the `PORT` environment
+variable to change it.

--- a/movieAPI_nodejs/index.js
+++ b/movieAPI_nodejs/index.js
@@ -1,0 +1,139 @@
+const express = require('express');
+
+const REPO_BASE_URL = 'https://raw.githubusercontent.com/Kgkkjjj/shows-/main/';
+const MOVIES_FILE = 'movies.json';
+const ANIME_FILE = 'anime.json';
+
+let moviesCache = [];
+let animeCache = [];
+let moviesCacheTime = 0;
+let animeCacheTime = 0;
+const CACHE_TTL = 300; // seconds
+
+async function fetchJson(file) {
+  try {
+    const res = await fetch(REPO_BASE_URL + file, { timeout: 5000 });
+    if (!res.ok) {
+      return [];
+    }
+    return await res.json();
+  } catch (err) {
+    return [];
+  }
+}
+
+function parseTitle(title) {
+  const m = /^(?<show>[^.]+)\.S(?<season>\d+)E(?<episode>\d+)/i.exec(title);
+  if (m && m.groups) {
+    return [m.groups.show, parseInt(m.groups.season), parseInt(m.groups.episode)];
+  }
+  return [null, null, null];
+}
+
+async function getMovies(force = false) {
+  const now = Date.now() / 1000;
+  if (!force && moviesCache.length && now - moviesCacheTime < CACHE_TTL) {
+    return moviesCache;
+  }
+  const raw = await fetchJson(MOVIES_FILE);
+  moviesCache = raw.map((item, idx) => {
+    const [show, season, episode] = parseTitle(item.title || '');
+    return {
+      id: idx + 1,
+      title: item.title,
+      path: item.path,
+      size_mb: item.size_mb,
+      show,
+      season,
+      episode,
+    };
+  });
+  moviesCacheTime = now;
+  return moviesCache;
+}
+
+async function getAnime(force = false) {
+  const now = Date.now() / 1000;
+  if (!force && animeCache.length && now - animeCacheTime < CACHE_TTL) {
+    return animeCache;
+  }
+  const raw = await fetchJson(ANIME_FILE);
+  animeCache = raw.map((item, idx) => ({ id: idx + 1, ...item }));
+  animeCacheTime = now;
+  return animeCache;
+}
+
+async function getMovie(id) {
+  const movies = await getMovies();
+  return movies.find((m) => m.id === id) || null;
+}
+
+async function getAnimeItem(id) {
+  const shows = await getAnime();
+  return shows.find((a) => a.id === id) || null;
+}
+
+async function searchMovies(query) {
+  const q = query.toLowerCase();
+  const movies = await getMovies();
+  return movies.filter((m) => m.title && m.title.toLowerCase().includes(q));
+}
+
+async function searchAnime(query) {
+  const q = query.toLowerCase();
+  const shows = await getAnime();
+  return shows.filter((a) => a.title && a.title.toLowerCase().includes(q));
+}
+
+async function refreshCache() {
+  await getMovies(true);
+  await getAnime(true);
+  return { movies: moviesCache.length, anime: animeCache.length };
+}
+
+const app = express();
+
+app.get('/movies', async (_req, res) => {
+  res.json({ movies: await getMovies() });
+});
+
+app.get('/movies/search', async (req, res) => {
+  const q = req.query.q || '';
+  res.json({ movies: await searchMovies(String(q)) });
+});
+
+app.get('/movies/:id', async (req, res) => {
+  const movie = await getMovie(parseInt(req.params.id, 10));
+  if (!movie) {
+    res.status(404).json({ detail: 'Movie not found' });
+  } else {
+    res.json(movie);
+  }
+});
+
+app.get('/anime', async (_req, res) => {
+  res.json({ anime: await getAnime() });
+});
+
+app.get('/anime/search', async (req, res) => {
+  const q = req.query.q || '';
+  res.json({ anime: await searchAnime(String(q)) });
+});
+
+app.get('/anime/:id', async (req, res) => {
+  const show = await getAnimeItem(parseInt(req.params.id, 10));
+  if (!show) {
+    res.status(404).json({ detail: 'Anime not found' });
+  } else {
+    res.json(show);
+  }
+});
+
+app.post('/refresh', async (_req, res) => {
+  res.json(await refreshCache());
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`movieAPI Node.js listening on ${PORT}`);
+});

--- a/movieAPI_nodejs/package.json
+++ b/movieAPI_nodejs/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "movieapi-nodejs",
+  "version": "1.0.0",
+  "description": "Node.js implementation of movieAPI",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/update_movies.py
+++ b/update_movies.py
@@ -1,0 +1,50 @@
+import json
+import requests
+import subprocess
+import sys
+from pathlib import Path
+
+REMOTE_URL = "https://raw.githubusercontent.com/Kgkkjjj/shows-/main/movies.json"
+LOCAL_PATH = Path("movies.json")
+GPG_KEY_ID = "9F28B4FCD2B9A0BE"
+
+
+def fetch_remote_movies():
+    resp = requests.get(REMOTE_URL, timeout=10)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def save_movies(data):
+    with LOCAL_PATH.open("w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+
+def git_commit(message: str):
+    subprocess.run(["git", "add", str(LOCAL_PATH)], check=True)
+    try:
+        subprocess.run(
+            [
+                "git",
+                "commit",
+                "-S",
+                f"--gpg-sign={GPG_KEY_ID}",
+                "-m",
+                message,
+            ],
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        # Fall back to unsigned commit if signing fails
+        subprocess.run(["git", "commit", "-m", message], check=True)
+
+
+def main():
+    message = sys.argv[1] if len(sys.argv) > 1 else "Update movies.json"
+    data = fetch_remote_movies()
+    save_movies(data)
+    git_commit(message)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- set up basic FastAPI server
- add data loader that fetches JSON from the `shows-` repository
- document how to run the API

## Testing
- `python -m py_compile main.py data_loader.py`
- `uvicorn main:app --port 8000` (manual test with curl)


------
https://chatgpt.com/codex/tasks/task_e_6844669072108330b2e3056a88e7a7c7